### PR TITLE
rfc citations as compounds

### DIFF
--- a/draft-rpc-rfc7322bis.xml
+++ b/draft-rpc-rfc7322bis.xml
@@ -158,13 +158,13 @@ block quotation.</t>
           </li>
         </ol>
         <section anchor="compounds" toc="default">
-          <name>RFCs as Compounds</name>
+          <name>RFC Citations as Compounds</name>
           <t>Whenever possible:
           </t>
           <ul spacing="normal">
             <li>Hyphenated compounds formed with RFC numbers should be avoided;
       this can be accomplished by: rewording the sentence (e.g., change "[RFC5011]-style
-      rollover" to "rollover as described in RFC 5011"). </li>
+      rollover" to "rollover as described in RFC 5011 [RFC5011]"). </li>
             <li>adding a note in either the Terminology or Conventions section mentioning
       the RFC so that other occurrences throughout the text will be understood by
       the reader to be in the style of said RFC (e.g., This document uses the term


### PR DESCRIPTION
Addresses these comments from John Klensin: 

1)	Avoid forming compounds by hyphenating RFC numbers; this
	can be accomplished by 
	
	   o rewording the sentence (e.g., "[RFC5011]-style
	rollover" –> "rollover as described in RFC
	5011").

Should that suggestion not read:

	"rollover as described in RFC 5011 [RFC5011]"

2) And, while I'm picking nits, ""RFCs as Compounds" is not a correct description of that subsection.  "RFC citations as Compounds" perhaps.